### PR TITLE
bump ethersphere/bee to v0.5.3

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "bee.dnp.dappnode.eth",
   "version": "0.1.5",
-  "upstreamVersion": "v0.5.1",
+  "upstreamVersion": "v0.5.3",
   "shortDescription": "Storage and communication infrastructure for a sovereign digital society",
   "description": "[Swarm](https://swarm.ethereum.org/) is a distributed storage platform and content distribution service, a native base layer service of the ethereum web3 stack. The primary objective of Swarm is to provide a decentralized and redundant store for dapp code and data as well as block chain and state data. Swarm is also set out to provide various base layer services for web3, including node-to-node messaging, media streaming, decentralized database services and scalable state-channel infrastructure for decentralized service economies. \n\n\n Learn about all you can do today with Swarm in the [Swarm documentation](https://docs.ethswarm.org/).",
   "type": "library",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ./build
       args:
-        UPSTREAM_VERSION: v0.5.1
+        UPSTREAM_VERSION: v0.5.3
     ports:
       - "1634:1634"
     volumes:


### PR DESCRIPTION
Bumps upstream version

- [ethersphere/bee](https://github.com/ethersphere/bee) from v0.5.1 to [v0.5.3](https://github.com/ethersphere/bee/releases/tag/v0.5.3)